### PR TITLE
added a range feature

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title></title>
+
+        <script src="radialIndicator.js"></script>
+
+    </head>
+    <body>
+        <div id="indicatorContainer">
+
+        </div>
+
+        <script>
+
+//Intialiazation 
+var radialObj = radialIndicator('#indicatorContainer', {
+
+    frameTime : 1,
+    barColor : '#87CEEB',
+    barWidth : 10,
+    displayNumber : false
+
+}); 
+
+
+// new api
+radialObj.value([50,70]);  
+radialObj.animate([10,95]); 
+
+// old api still works
+/*
+radialObj.value(5);  
+radialObj.animate(60); 
+*/
+
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
this PR introduces a feature that allows to specify both start and end values
see live demo - http://plnkr.co/edit/bRJtRKGkSXJJm8O2lQwo?p=info

new api
```javascript
radialObj.value([50,70]);  
radialObj.animate([10,95]); 
```
This does not break old api, it still works:
```javascript
radialObj.value(5);  
radialObj.animate(60); 
```
It is now similar to the features in http://roundsliderui.com/
This PR suites my own needs, but it could be improved to handle both start and end display values, API callback values and more.