### PR TITLE
feat: add support for reverse direction rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Check demo and documentation on <a href="http://ignitersworld.com/lab/radialIndi
 
 <h3>Major updates</h3>
 
+<strong>1.4.0</strong>
+- Added option to support rendering in the opposite direction.
+
 <strong>1.2.0</strong>
 - Added option to allow user interaction on mouse and touch events.
 - Added precision option to support float value.

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
         "name": "Sudhanshu Yadav",
         "email": "sudhanshuyadav2@gmail.com"
     },
-    "version": "1.3.1",
+    "version": "1.4.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/s-yadav/radialIndicator"

--- a/radialIndicator.js
+++ b/radialIndicator.js
@@ -415,6 +415,7 @@
 
     //radial indicator defaults
     radialIndicator.defaults = {
+        reverse: false,
         radius: 50, //inner radius of indicator
         barWidth: 5, //bar width
         barBgColor: '#eeeeee', //unfilled bar color

--- a/radialIndicator.js
+++ b/radialIndicator.js
@@ -319,7 +319,17 @@
             if (indOption.roundCorner) ctx.lineCap = "round";
 
             ctx.beginPath();
-            ctx.arc(center, center, indOption.radius - 1 + indOption.barWidth / 2, -(quart), ((circ) * perVal / 100) - quart, false);
+            var start, end
+            if (indOption.reverse) {
+                start = circ * ((100 - perVal) / 100) - quart
+                // Start and end can't be equal or nothing is rendered
+                // so shave of a tiny amount of the end
+                end = (-quart) - 0.00001
+            } else {
+                start = -(quart)
+                end = ((circ) * perVal / 100) - quart
+            }
+            ctx.arc(center, center, indOption.radius - 1 + indOption.barWidth / 2, start, end, false);
             ctx.stroke();
 
             //add percentage text


### PR DESCRIPTION
Allows developers to pass a `reverse` option to render the indicator in the opposite direction.